### PR TITLE
linux-firmware: apply workaround for qcs6490 WiFi firmware

### DIFF
--- a/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
+++ b/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
@@ -1,0 +1,2 @@
+# temporal workaround until this RPROVIDES is merged into OE-Core
+RPROVIDES:${PN}-qcom-qcm6490-wifi:qcom = "${PN}-qcom-qcs6490-wifi"


### PR DESCRIPTION
Work around the file conflict between linux-firmware-qcom-qcm6490-wifi (from linux-firmware) and linux-firmware-qcom-qcs6490-wifi (from firmware-qcom-rb3gen2) by making the first one RPROVIDE the second one.