### PR TITLE
qcom-armv7a-modem: restore machine configuration

### DIFF
--- a/conf/machine/qcom-armv7a-modem.conf
+++ b/conf/machine/qcom-armv7a-modem.conf
@@ -1,0 +1,37 @@
+#@TYPE: Machine
+#@NAME: Qualcomm SDX/MDM devices
+#@DESCRIPTION: Machine configuration for various Qualcomm SDX and MDM based boards
+
+require conf/machine/include/qcom-common.inc
+# MDM9615 is Cortex-A5 + VFP4, so it should be compatible
+require conf/machine/include/arm/armv7a/tune-cortexa7.inc
+
+MACHINE_FEATURES = "usbhost usbgadget"
+
+MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
+    qrtr \
+    rmtfs \
+"
+
+KERNEL_IMAGETYPE ?= "zImage"
+KERNEL_DEVICETREE ?= " \
+    qcom/qcom-mdm9615-wp8548-mangoh-green.dtb \
+    qcom/qcom-sdx55-mtp.dtb \
+    qcom/qcom-sdx55-t55.dtb \
+    qcom/qcom-sdx55-telit-fn980-tlb.dtb \
+    qcom/qcom-sdx65-mtp.dtb \
+"
+
+SERIAL_CONSOLES[qcom-sdx55-telit-fn980-tlb] = "921600;ttyMSM0"
+
+# UBI filesystem settings
+IMAGE_FSTYPES ?= "ubi"
+QCOM_BOOTIMG_PAGE_SIZE ?= "4096"
+
+# UBI filesystem parameters
+MKUBIFS_ARGS ?= "-m 4096 -e 253952 -c 1188"
+UBINIZE_ARGS ?= "-m 4096 -p 256KiB -s 4096"
+
+# Use system partition for rootfs
+UBI_VOLNAME ?= "system"
+QCOM_BOOTIMG_ROOTFS ?= "ubi0:system"


### PR DESCRIPTION
Restore ARMv7a modem machine configuration, it has been dropped from meta-qcom.