### PR TITLE
Revert "linux-firmware: apply workaround for qcs6490 WiFi firmware"

### DIFF
--- a/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
+++ b/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
@@ -1,2 +1,0 @@
-# temporal workaround until this RPROVIDES is merged into OE-Core
-RPROVIDES:${PN}-qcom-qcm6490-wifi:qcom = "${PN}-qcom-qcs6490-wifi"


### PR DESCRIPTION
This reverts commit 3b73382a3e56 ("linux-firmware: apply workaround for qcs6490 WiFi firmware"). Corresponding change has been merged to OE-Core, so there is no need to override it.