### PR TITLE
initramfs-firmware-mega-image: drop extra x13s dependency

### DIFF
--- a/recipes-bsp/images/initramfs-firmware-mega-image.bbappend
+++ b/recipes-bsp/images/initramfs-firmware-mega-image.bbappend
@@ -1,11 +1,5 @@
-
 # Inforce / Penguin Edge devkits
 PACKAGE_INSTALL += " \
     packagegroup-firmware-ifc6410 \
     packagegroup-firmware-ifc6560 \
-"
-
-# Other devices
-PACKAGE_INSTALL += " \
-    packagegroup-firmware-lenovo-x13s \
 "


### PR DESCRIPTION
The packagegroup-firmware-lenovo-x13s is already pulled in images-woa/ bbappend. Stop pulling it in via tha images/ bbappend.

