### PR TITLE
firmware-qcom-pixel: handle more DSP locations

### DIFF
--- a/recipes-bsp/firmware-nexus/firmware-qcom-pixel.inc
+++ b/recipes-bsp/firmware-nexus/firmware-qcom-pixel.inc
@@ -33,7 +33,7 @@ do_extract() {
         ln -sr ${S}/vendor/${VENDOR}/${FW_QCOM_NAME}/proprietary/vendor.img ${B}/vendor.img
     fi
 
-    for path in firmware dsp/adsp dsp/cdsp dsp/sdsp lib/rfsa/adsp ; do
+    for path in firmware dsp/adsp dsp/cdsp dsp/sdsp lib/dsp lib/rfsa/adsp ; do
         mkdir -p ${B}/$path
         debugfs ${B}/vendor.img -R "ls -p /$path" | \
             grep '^/[0-9]*/100' | cut -d/ -f6 | \
@@ -83,6 +83,7 @@ do_install() {
     ls ${B}/dsp/adsp/* && mkdir -p ${D}${DSP_QCOM_PATH}/dsp/adsp && install -m 0644 ${B}/dsp/adsp/* ${D}${DSP_QCOM_PATH}/dsp/adsp
     ls ${B}/dsp/cdsp/* && mkdir -p ${D}${DSP_QCOM_PATH}/dsp/cdsp && install -m 0644 ${B}/dsp/cdsp/* ${D}${DSP_QCOM_PATH}/dsp/cdsp
     ls ${B}/dsp/sdsp/* && mkdir -p ${D}${DSP_QCOM_PATH}/dsp/sdsp && install -m 0644 ${B}/dsp/sdsp/* ${D}${DSP_QCOM_PATH}/dsp/sdsp
+    ls ${B}/lib/dsp/* && mkdir -p ${D}${DSP_QCOM_PATH}/dsp/adsp && install -m 0644 ${B}/lib/dsp/* ${D}${DSP_QCOM_PATH}/dsp/adsp
     ls ${B}/lib/rfsa/adsp/* && mkdir -p ${D}${DSP_QCOM_PATH}/dsp/lib && install -m 0644 ${B}/lib/rfsa/adsp/* ${D}${DSP_QCOM_PATH}/dsp/lib
 
     install -m 0644 license.txt ${D}${FW_QCOM_PATH}


### PR DESCRIPTION
Unpack ADSP firmware from vendor.img/lib/dsp.