### PR TITLE
packagegroups: follow the meta-qcom packagegroup rework

### DIFF
--- a/recipes-bsp/images-woa/initramfs-firmware-ecs-liva-qc710-image.bb
+++ b/recipes-bsp/images-woa/initramfs-firmware-ecs-liva-qc710-image.bb
@@ -1,7 +1,7 @@
 DESCRIPTION = "Tiny ramdisk image with ECS Liva QC710 devices firmware files"
 
 PACKAGE_INSTALL += " \
-    packagegroup-firmware-ecs-liva-qc710 \
+    packagegroup-ecs-liva-qc710-firmware \
 "
 
 require recipes-bsp/images/initramfs-firmware-image.inc

--- a/recipes-bsp/images-woa/initramfs-firmware-lenovo-miix-630-image.bb
+++ b/recipes-bsp/images-woa/initramfs-firmware-lenovo-miix-630-image.bb
@@ -1,7 +1,7 @@
 DESCRIPTION = "Tiny ramdisk image with Lenovo Miix 630 firmware files"
 
 PACKAGE_INSTALL += " \
-    packagegroup-firmware-lenovo-miix-630 \
+    packagegroup-lenovo-miix-630-firmware \
 "
 
 require recipes-bsp/images/initramfs-firmware-image.inc

--- a/recipes-bsp/images-woa/initramfs-firmware-lenovo-t14s-g6-image.bb
+++ b/recipes-bsp/images-woa/initramfs-firmware-lenovo-t14s-g6-image.bb
@@ -1,7 +1,7 @@
 DESCRIPTION = "Tiny ramdisk image with Lenovo T14s G6 firmware files"
 
 PACKAGE_INSTALL += " \
-    packagegroup-firmware-lenovo-t14s-g6 \
+    packagegroup-lenovo-t14s-g6-firmware \
 "
 
 require recipes-bsp/images/initramfs-firmware-image.inc

--- a/recipes-bsp/images-woa/initramfs-firmware-lenovo-x13s-image.bb
+++ b/recipes-bsp/images-woa/initramfs-firmware-lenovo-x13s-image.bb
@@ -1,7 +1,7 @@
 DESCRIPTION = "Tiny ramdisk image with Lenovo X13s firmware files"
 
 PACKAGE_INSTALL += " \
-    packagegroup-firmware-lenovo-x13s \
+    packagegroup-lenovo-x13s-firmware \
 "
 
 require recipes-bsp/images/initramfs-firmware-image.inc

--- a/recipes-bsp/images-woa/initramfs-firmware-lenovo-yoga-c630-image.bb
+++ b/recipes-bsp/images-woa/initramfs-firmware-lenovo-yoga-c630-image.bb
@@ -1,7 +1,7 @@
 DESCRIPTION = "Tiny ramdisk image with Lenovo Yoga C630 firmware files"
 
 PACKAGE_INSTALL += " \
-    packagegroup-firmware-lenovo-yoga-c630 \
+    packagegroup-lenovo-yoga-c630-firmware \
 "
 
 require recipes-bsp/images/initramfs-firmware-image.inc

--- a/recipes-bsp/images-woa/initramfs-firmware-mega-image.bbappend
+++ b/recipes-bsp/images-woa/initramfs-firmware-mega-image.bbappend
@@ -1,9 +1,9 @@
 # WoA devices
 PACKAGE_INSTALL += " \
-    packagegroup-firmware-ecs-liva-qc710 \
-    packagegroup-firmware-lenovo-miix-630 \
-    packagegroup-firmware-lenovo-yoga-c630 \
-    packagegroup-firmware-lenovo-x13s \
-    packagegroup-firmware-sc8180x \
-    packagegroup-firmware-x1e80100-crd \
+    packagegroup-ecs-liva-qc710-firmware \
+    packagegroup-lenovo-miix-630-firmware \
+    packagegroup-lenovo-yoga-c630-firmware \
+    packagegroup-lenovo-x13s-firmware \
+    packagegroup-sc8180x-firmware \
+    packagegroup-x1e80100-crd-firmware \
 "

--- a/recipes-bsp/images-woa/initramfs-firmware-sc8180x-image.bb
+++ b/recipes-bsp/images-woa/initramfs-firmware-sc8180x-image.bb
@@ -1,7 +1,7 @@
 DESCRIPTION = "Tiny ramdisk image with SC8180X devices firmware files"
 
 PACKAGE_INSTALL += " \
-    packagegroup-firmware-sc8180x \
+    packagegroup-sc8180x-firmware \
 "
 
 BAD_RECOMMENDATIONS = " \

--- a/recipes-bsp/images-woa/initramfs-firmware-x1e80100-crd-image.bb
+++ b/recipes-bsp/images-woa/initramfs-firmware-x1e80100-crd-image.bb
@@ -1,7 +1,7 @@
 DESCRIPTION = "Tiny ramdisk image with X1E80100 CRD devices firmware files"
 
 PACKAGE_INSTALL += " \
-    packagegroup-firmware-x1e80100-crd \
+    packagegroup-x1e80100-crd-firmware \
 "
 
 BAD_RECOMMENDATIONS = " \

--- a/recipes-bsp/images/initramfs-firmware-ifc6410-image.bb
+++ b/recipes-bsp/images/initramfs-firmware-ifc6410-image.bb
@@ -1,7 +1,7 @@
 DESCRIPTION = "Tiny ramdisk image with IFC6410 firmware files"
 
 PACKAGE_INSTALL += " \
-    packagegroup-firmware-ifc6410 \
+    packagegroup-ifc6410-firmware \
 "
 
 require recipes-bsp/images/initramfs-firmware-image.inc

--- a/recipes-bsp/images/initramfs-firmware-ifc6560-image.bb
+++ b/recipes-bsp/images/initramfs-firmware-ifc6560-image.bb
@@ -1,7 +1,7 @@
 DESCRIPTION = "Tiny ramdisk image with all Nexus and Pixel devices firmware files"
 
 PACKAGE_INSTALL += " \
-    packagegroup-firmware-ifc6560 \
+    packagegroup-ifc6560-firmware \
 "
 
 BAD_RECOMMENDATIONS = "\

--- a/recipes-bsp/images/initramfs-firmware-mega-image.bbappend
+++ b/recipes-bsp/images/initramfs-firmware-mega-image.bbappend
@@ -1,5 +1,5 @@
 # Inforce / Penguin Edge devkits
 PACKAGE_INSTALL += " \
-    packagegroup-firmware-ifc6410 \
-    packagegroup-firmware-ifc6560 \
+    packagegroup-ifc6410-firmware \
+    packagegroup-ifc6560-firmware \
 "

--- a/recipes-bsp/packagegroups-woa/packagegroup-ecs-liva-qc710.bb
+++ b/recipes-bsp/packagegroups-woa/packagegroup-ecs-liva-qc710.bb
@@ -1,8 +1,12 @@
-SUMMARY = "Firmware packages for the ECS LIVA QC710 devices"
+SUMMARY = "Packages for the ECS LIVA QC710 devices"
 
 inherit packagegroup
 
-RRECOMMENDS:${PN} += " \
+PACKAGES = " \
+    ${PN}-firmware \
+"
+
+RRECOMMENDS:${PN}-firmware = " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a630 linux-firmware-qcom-ecs-liva-qc710-adreno', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca-wcn399x', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath10k-wcn3990 linux-firmware-qcom-ecs-liva-qc710-wifi', '', d)} \

--- a/recipes-bsp/packagegroups-woa/packagegroup-lenovo-miix-630.bb
+++ b/recipes-bsp/packagegroups-woa/packagegroup-lenovo-miix-630.bb
@@ -1,8 +1,12 @@
-SUMMARY = "Firmware packages for the Lenogo Miix 630 laptop"
+SUMMARY = "Packages for the Lenogo Miix 630 laptop"
 
 inherit packagegroup
 
-RRECOMMENDS:${PN} += " \
+PACKAGES = " \
+    ${PN}-firmware \
+"
+
+RRECOMMENDS:${PN}-firmware = " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a630 linux-firmware-qcom-lenovo-miix-630-adreno', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca-wcn399x', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath10k-wcn3990', '', d)} \

--- a/recipes-bsp/packagegroups-woa/packagegroup-lenovo-t14s-g6.bb
+++ b/recipes-bsp/packagegroups-woa/packagegroup-lenovo-t14s-g6.bb
@@ -1,8 +1,12 @@
-SUMMARY = "Firmware packages for the Lenovo T14s G6 laptop"
+SUMMARY = "Packages for the Lenovo T14s G6 laptop"
 
 inherit packagegroup
 
-RRECOMMENDS:${PN} += " \
+PACKAGES = " \
+    ${PN}-firmware \
+"
+
+RRECOMMENDS:${PN}-firmware = " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-g750 linux-firmware-qcom-x1e80100-lenovo-t14s-g6-adreno', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath12k-wcn7850', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca-wcn7850', '', d)} \

--- a/recipes-bsp/packagegroups-woa/packagegroup-lenovo-x13s.bb
+++ b/recipes-bsp/packagegroups-woa/packagegroup-lenovo-x13s.bb
@@ -1,8 +1,12 @@
-SUMMARY = "Firmware packages for the Lenovo X13s laptop"
+SUMMARY = "Packages for the Lenovo X13s laptop"
 
 inherit packagegroup
 
-RRECOMMENDS:${PN} += " \
+PACKAGES = " \
+    ${PN}-firmware \
+"
+
+RRECOMMENDS:${PN}-firmware = " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a660 linux-firmware-qcom-sc8280xp-lenovo-x13s-adreno', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath11k-wcn6855', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca-qca2066', '', d)} \

--- a/recipes-bsp/packagegroups-woa/packagegroup-lenovo-yoga-c630.bb
+++ b/recipes-bsp/packagegroups-woa/packagegroup-lenovo-yoga-c630.bb
@@ -1,8 +1,12 @@
-SUMMARY = "Firmware packages for the Lenogo Yoga C630 laptop"
+SUMMARY = "Packages for the Lenogo Yoga C630 laptop"
 
 inherit packagegroup
 
-RRECOMMENDS:${PN} += " \
+PACKAGES = " \
+    ${PN}-firmware \
+"
+
+RRECOMMENDS:${PN}-firmware = " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a630 linux-firmware-qcom-lenovo-yoga-c630-adreno', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca-wcn399x', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath10k-wcn3990', '', d)} \

--- a/recipes-bsp/packagegroups-woa/packagegroup-sc8180x.bb
+++ b/recipes-bsp/packagegroups-woa/packagegroup-sc8180x.bb
@@ -1,8 +1,12 @@
-SUMMARY = "Firmware packages for the SC8180X devices"
+SUMMARY = "Packages for the SC8180X devices"
 
 inherit packagegroup
 
-RRECOMMENDS:${PN} += " \
+PACKAGES = " \
+    ${PN}-firmware \
+"
+
+RRECOMMENDS:${PN}-firmware = " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a640 linux-firmware-qcom-sc8180x-adreno', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca-wcn399x', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath10k-wcn3990', '', d)} \

--- a/recipes-bsp/packagegroups-woa/packagegroup-x1e80100-crd.bb
+++ b/recipes-bsp/packagegroups-woa/packagegroup-x1e80100-crd.bb
@@ -1,8 +1,12 @@
-SUMMARY = "Firmware packages for the X1E80100 CRD devices"
+SUMMARY = "Packages for the X1E80100 CRD devices"
 
 inherit packagegroup
 
-RRECOMMENDS:${PN} += " \
+PACKAGES = " \
+    ${PN}-firmware \
+"
+
+RRECOMMENDS:${PN}-firmware = " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-g750 linux-firmware-qcom-x1e80100-adreno', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca-wcn7850', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath12k-wcn7850 linux-firmware-qcom-x1e80100-wifi', '', d)} \

--- a/recipes-bsp/packagegroups/packagegroup-ifc6410.bb
+++ b/recipes-bsp/packagegroups/packagegroup-ifc6410.bb
@@ -1,8 +1,12 @@
-SUMMARY = "Firmware packages for the IFC6410 board"
+SUMMARY = "Packages for the IFC6410 board"
 
 inherit packagegroup
 
-RRECOMMENDS:${PN} += " \
+PACKAGES = " \
+    ${PN}-firmware \
+"
+
+RRECOMMENDS:${PN}-firmware = " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a3xx', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath6k firmware-ath6kl', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-ar3k', '', d)} \

--- a/recipes-bsp/packagegroups/packagegroup-ifc6560.bb
+++ b/recipes-bsp/packagegroups/packagegroup-ifc6560.bb
@@ -1,8 +1,12 @@
-SUMMARY = "Firmware packages for the IFC6560 board"
+SUMMARY = "Packages for the IFC6560 board"
 
 inherit packagegroup
 
-RRECOMMENDS:${PN} += " \
+PACKAGES = " \
+    ${PN}-firmware \
+"
+
+RRECOMMENDS:${PN}-firmware = " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a530 linux-firmware-qcom-sda660-adreno', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath10k-wcn3990', '', d)} \


### PR DESCRIPTION
Mass-rename packagegroups to follow corresponding changes in meta-qcom.