### PR TITLE
Compress all firmware

### DIFF
--- a/recipes-bsp/firmware-nexus/firmware-qcom-nexus.inc
+++ b/recipes-bsp/firmware-nexus/firmware-qcom-nexus.inc
@@ -24,7 +24,7 @@ do_compile() {
     done
 }
 
-do_install() {
+do_install:prepend() {
     install -d ${D}${FW_QCOM_PATH}
     install -m 0644 license.txt ${D}${FW_QCOM_PATH}
 }

--- a/recipes-bsp/firmware-nexus/firmware-qcom-nexus4.bb
+++ b/recipes-bsp/firmware-nexus/firmware-qcom-nexus4.bb
@@ -18,7 +18,7 @@ PV:append = "+git${SRCPV}"
 
 RDEPENDS:${PN} += "linux-firmware-qcom-adreno-a3xx"
 
-do_install:append() {
+do_install:prepend() {
     install -d ${D}${FW_QCOM_PATH}
 
     install -m 0644 dsps.mbn ${D}${FW_QCOM_PATH}

--- a/recipes-bsp/firmware-nexus/firmware-qcom-nexus5.bb
+++ b/recipes-bsp/firmware-nexus/firmware-qcom-nexus5.bb
@@ -15,7 +15,7 @@ require recipes-bsp/firmware-nexus/firmware-qcom-nexus.inc
 RADIO_VFAT = "1"
 require recipes-bsp/firmware-nexus/firmware-qcom-radio.inc
 
-do_install:append() {
+do_install:prepend() {
     install -d ${D}${FW_QCOM_PATH}
 
     install -m 0644 adsp.mbn ${D}${FW_QCOM_PATH}

--- a/recipes-bsp/firmware-nexus/firmware-qcom-nexus6.bb
+++ b/recipes-bsp/firmware-nexus/firmware-qcom-nexus6.bb
@@ -11,7 +11,7 @@ RDEPENDS:${PN} += "linux-firmware-qcom-adreno-a4xx"
 
 require recipes-bsp/firmware-nexus/firmware-qcom-nexus.inc
 
-do_install:append() {
+do_install:prepend() {
     install -d ${D}${FW_QCOM_PATH}
 
     install -m 0644 adsp.mbn ${D}${FW_QCOM_PATH}

--- a/recipes-bsp/firmware-nexus/firmware-qcom-nexus7-2013.bb
+++ b/recipes-bsp/firmware-nexus/firmware-qcom-nexus7-2013.bb
@@ -15,7 +15,7 @@ SRC_URI += "git://android.googlesource.com/device/asus/${FW_QCOM_NAME};protocol=
 SRCREV_aosp = "9d9fee956a9c4c7be4f69f7a472d3fc0e759c2dd"
 PV:append = "+git${SRCPV}"
 
-do_install:append() {
+do_install:prepend() {
     install -d ${D}${FW_QCOM_PATH}
 
     install -m 0644 dsps.mbn ${D}${FW_QCOM_PATH}

--- a/recipes-bsp/firmware-nexus/firmware-qcom-pixel.inc
+++ b/recipes-bsp/firmware-nexus/firmware-qcom-pixel.inc
@@ -68,7 +68,7 @@ do_compile() {
     done
 }
 
-do_install() {
+do_install:prepend() {
     install -d ${D}${FW_QCOM_PATH}
     for fw in adsp cdsp ipa_fws modem slpi venus ; do
         ls ${B}/$fw*.mbn && install -m 0644 ${B}/$fw*.mbn ${D}${FW_QCOM_PATH}

--- a/recipes-bsp/firmware-nexus/firmware-qcom-pixel2.bb
+++ b/recipes-bsp/firmware-nexus/firmware-qcom-pixel2.bb
@@ -12,6 +12,7 @@ RDEPENDS:${PN} += "linux-firmware-qcom-adreno-a530"
 
 require firmware-qcom-pixel.inc
 
-do_install:append() {
+do_install:prepend() {
+    install -d ${D}${FW_QCOM_BASE_PATH}
     install -m 0644 ${B}/firmware/a540_gpmu.fw2 ${D}${FW_QCOM_BASE_PATH}
 }

--- a/recipes-bsp/firmware-nexus/firmware-qcom-radio.inc
+++ b/recipes-bsp/firmware-nexus/firmware-qcom-radio.inc
@@ -28,7 +28,7 @@ do_compile:append() {
     fi
 }
 
-do_install:append() {
+do_install:prepend() {
     install -d ${D}${FW_QCOM_PATH}
     install -m 0644 ${B}/radio/*.mbn ${D}${FW_QCOM_PATH}
 }

--- a/recipes-bsp/firmware-woa/firmware-woa.inc
+++ b/recipes-bsp/firmware-woa/firmware-woa.inc
@@ -23,7 +23,7 @@ do_compile:append() {
     fi
 }
 
-do_install:append() {
+do_install:prepend() {
     install -d ${D}${FW_QCOM_PATH}
 
     install -m 0644 ${B}/*.mbn ${D}${FW_QCOM_PATH}


### PR DESCRIPTION
As a part of do_install() we are compressing installed files. If other firmware is installed via appending to do_install(), it might get installed after compression happens, thus landing uncompressed. Move Adreno firmware installation to do_install:prepend() to make sure that it gets installed before compression step.